### PR TITLE
Fix weapon selection wraparound bug

### DIFF
--- a/Source/ARPG/Private/Inventory/Component/NAInventoryComponent.cpp
+++ b/Source/ARPG/Private/Inventory/Component/NAInventoryComponent.cpp
@@ -433,16 +433,16 @@ UNAItemData* UNAInventoryComponent::SelectNextWeapon(int32 Direction) const
 {
 	if (FMath::Abs(Direction) != 1) return nullptr;
 
-	int32 MaxWeaponIndex = MaxWeaponSlotCount - 1;
-	int32 NewIndex;
-	if (EquippedWeaponIndex == -1)
-	{
-		NewIndex = Direction > 0 ? 0 : MaxWeaponIndex;
-	}
-	else
-	{
-		NewIndex = (EquippedWeaponIndex + Direction + MaxWeaponIndex) % MaxWeaponIndex;
-	}
+       int32 MaxWeaponIndex = MaxWeaponSlotCount - 1;
+       int32 NewIndex;
+       if (EquippedWeaponIndex == -1)
+       {
+               NewIndex = Direction > 0 ? 0 : MaxWeaponIndex;
+       }
+       else
+       {
+               NewIndex = (EquippedWeaponIndex + Direction + MaxWeaponSlotCount) % MaxWeaponSlotCount;
+       }
 	if (FMath::IsWithinInclusive(NewIndex, 0, MaxWeaponIndex))
 	{
 		FName WeaponSlotID = MakeWeaponSlotID(NewIndex);


### PR DESCRIPTION
## Summary
- ensure weapon index wraps correctly when cycling weapons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d9a0fd4b48329a9295704e83d940a